### PR TITLE
Trim non-functional annotations and unused dependencies from Java SDK

### DIFF
--- a/codegen/Templates/java/JSON.mustache
+++ b/codegen/Templates/java/JSON.mustache
@@ -9,8 +9,6 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import com.google.gson.JsonElement;
-import io.gsonfire.GsonFireBuilder;
-import io.gsonfire.TypeSelector;
 {{#joda}}
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -47,8 +45,7 @@ public class JSON {
     private Gson gson;
 
     private static GsonBuilder createGson() {
-        GsonFireBuilder fireBuilder = new GsonFireBuilder();
-        GsonBuilder builder = fireBuilder.createGsonBuilder();
+        GsonBuilder builder = new GsonBuilder();
         {{#disableHtmlEscaping}}
         builder.disableHtmlEscaping();
         {{/disableHtmlEscaping}}

--- a/codegen/Templates/java/model.mustache
+++ b/codegen/Templates/java/model.mustache
@@ -29,8 +29,6 @@ import android.os.Parcel;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 {{/useBeanValidation}}
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 
 {{#models}}
 {{#model}}

--- a/codegen/Templates/java/pojo.mustache
+++ b/codegen/Templates/java/pojo.mustache
@@ -1,7 +1,6 @@
 /**
  * {{#description}}{{.}}{{/description}}{{^description}}{{classname}}{{/description}}
- */{{#description}}
-@ApiModel(description = "{{{description}}}"){{/description}}
+ */
 {{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 
 {{#notNullJacksonAnnotation}}@JsonInclude(JsonInclude.Include.NON_NULL){{/notNullJacksonAnnotation}}
@@ -154,7 +153,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{/maximum}}
    * @return {{name}}
    */
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{nameInCamelCase}}}")
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}
 {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}
 {{/vendorExtensions.extraAnnotation}}

--- a/codegen/Templates/java/pom.mustache
+++ b/codegen/Templates/java/pom.mustache
@@ -201,11 +201,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-annotations</artifactId>
-            <version>${swagger-core-version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>${okhttp-version}</version>
@@ -219,16 +214,6 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.gsonfire</groupId>
-            <artifactId>gson-fire</artifactId>
-            <version>${gson-fire-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>3.0.0</version>
         </dependency>
         {{#joda}}
             <dependency>
@@ -294,10 +279,7 @@
         <java.version>{{#java8}}11{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <gson-fire-version>1.9.0</gson-fire-version>
-        {{! Check version compatibility with gson-fire }}
-        <gson-version>2.13.2</gson-version>
-        <swagger-core-version>1.6.16</swagger-core-version>
+        <gson-version>2.14.0</gson-version>
         <okhttp-version>5.3.2</okhttp-version>
         {{#joda}}
             <jodatime-version>2.9.9</jodatime-version>


### PR DESCRIPTION
  Drop three Maven dependencies that contribute nothing at runtime, plus
  the Swagger annotations they backed, and bump Gson to the current minor.

  Dependencies removed from pom.mustache:
  - jakarta.annotation-api: orphaned when the previous commit stopped emitting @jakarta.annotation.Generated from generatedAnnotation.mustache.
  - io.swagger:swagger-annotations: pulled in solely for @ApiModel and @ApiModelProperty — Swagger 1.x doc metadata with no consumer in this SDK (no swagger-ui generation, no reflective lookup).
  - io.gsonfire:gson-fire: used in JSON.java only as `new GsonFireBuilder().createGsonBuilder()` — no post-processors, type selectors, or hooks were ever configured, so it was equivalent to `new GsonBuilder()`.

  Template changes:
  - pojo.mustache: stop emitting @ApiModel on classes and @ApiModelProperty on getters.
  - model.mustache: drop the two io.swagger.annotations.* imports.
  - JSON.mustache: drop the GsonFireBuilder / TypeSelector imports and use `new GsonBuilder()` directly in createGson().
  - pom.mustache: drop the three <dependency> blocks, the <swagger-core-version> and <gson-fire-version> properties, and bump gson 2.13.2 -> 2.14.0.